### PR TITLE
Allow flighttime to be > 23hr59

### DIFF
--- a/js/pred/pred-new.js
+++ b/js/pred/pred-new.js
@@ -325,7 +325,7 @@ function plotStandardPrediction(prediction){
     // Calculate range and time of flight
     var range = distHaversine(launch.latlng, landing.latlng, 1);
     var flighttime = "";
-    var f_hours = Math.floor((prediction.flight_time % 86400) / 3600);
+    var f_hours = Math.floor(prediction.flight_time / 3600);
     var f_minutes = Math.floor(((prediction.flight_time % 86400) % 3600) / 60);
     if ( f_minutes < 10 ) f_minutes = "0"+f_minutes;
     flighttime = f_hours + "hr" + f_minutes;


### PR DESCRIPTION
2 of 2 - Allow flighttime to be > 23hr59, stopping a floater having "Flight Time: 0hr00" or any flight over 23hr59 showing a flight time of less than 24 hours.

Fixing https://github.com/projecthorus/leaflet_predictor/issues/5