### PR TITLE
Fix ascent rate in URL

### DIFF
--- a/js/pred/pred.js
+++ b/js/pred/pred.js
@@ -63,7 +63,7 @@ function readURLParams() {
         $("#initial_alt").val(url.searchParams.get('launch_altitude'));
     }
     if(url.searchParams.has('ascent_rate')){
-        $("#ascent_rate").val(url.searchParams.get('ascent_rate'));
+        $("#ascent").val(url.searchParams.get('ascent_rate'));
     }
     if(url.searchParams.has('descent_rate')){
         $("#drag").val(url.searchParams.get('descent_rate'));


### PR DESCRIPTION
There was a mismatch in field names that lead to ascent rate not getting stored in the URL properly, this fixes that.